### PR TITLE
bcdice/extratables内のコマンドに反応するように修整

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -22,6 +22,7 @@ helpers do
     bcdice = BCDiceMaker.new.newBcDice
     bcdice.setDiceBot(dicebot)
     bcdice.setMessage(command)
+    bcdice.setDir("bcdice/extratables",system)
     bcdice.setCollectRandResult(true)
 
     result, secret = bcdice.dice_command


### PR DESCRIPTION
bcdice/extratables内のコマンドに反応していない罠があったので修整しました。
（例：KanColleのWPFAなど）
