### PR TITLE
計算コマンドに対応する

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - 2.6
   - 2.5
   - 2.4
-  - 2.3
 
 script:
   - bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ desc "Run test-unit based test"
 Rake::TestTask.new do |t|
   # To run test for only one file (or file path pattern)
   #  $ bundle exec rake test TEST=test/test_specified_path.rb
-  t.libs << "test"
+  t.libs += ["lib", "bcdice/src"]
   t.test_files = Dir["test/test_*.rb"]
   t.verbose = true
 end

--- a/lib/bcdice_wrap.rb
+++ b/lib/bcdice_wrap.rb
@@ -18,6 +18,20 @@ class BCDice
     map { |gameType, diceBot| {system: gameType, name: diceBot.gameName} }.
     freeze
 
+  # 与えられた文字列が計算コマンドのようであるかを返す
+  # @param [String] s 調べる文字列
+  # @return [true] sが計算コマンドのようであった場合
+  # @return [false] sが計算コマンドではない場合
+  #
+  # 詳細な構文解析は行わない。
+  # 計算コマンドで使われ得る文字のみで構成されているかどうかだけを調べる。
+  def self.seem_to_be_calc?(s)
+    # 空白が含まれる場合、最初の部分だけを取り出す
+    target = s.split(/\s/, 2).first
+
+    return %r{\AC\([-+*/()\d]+\)\z}i === target
+  end
+
   def dice_command   # ダイスコマンドの分岐処理
     arg = @message.upcase
 
@@ -47,6 +61,24 @@ class BCDice
     output = nil #BCDiceからの変更点
     secret = nil
     return output, secret
+  end
+
+  # 計算コマンドの実行を試みる
+  # @return [Array<String, false>] 計算コマンドの実行に成功した場合
+  # @return [nil, nil] 計算コマンドの実行に失敗した場合
+  #
+  # 返り値の2つ目の要素は、`result, secret =` と受け取れるようにするために
+  # 用意している。
+  def try_calc_command
+    stripped_message = @message.strip
+    matches = stripped_message.match(/\AC([-\d]+\z)/i)
+
+    if matches.nil?
+      return nil, nil
+    end
+
+    calc_result = matches[1]
+    return "#{@diceBot.gameType} : 計算結果 ＞ #{calc_result}", false
   end
 end
 

--- a/lib/bcdice_wrap.rb
+++ b/lib/bcdice_wrap.rb
@@ -78,7 +78,7 @@ class BCDice
     end
 
     calc_result = matches[1]
-    return "#{@diceBot.gameType} : 計算結果 ＞ #{calc_result}", false
+    return ": 計算結果 ＞ #{calc_result}", false
   end
 end
 

--- a/lib/bcdice_wrap.rb
+++ b/lib/bcdice_wrap.rb
@@ -29,7 +29,7 @@ class BCDice
     # 空白が含まれる場合、最初の部分だけを取り出す
     target = s.split(/\s/, 2).first
 
-    return %r{\AC\([-+*/()\d]+\)\z}i === target
+    return target.match?(%r{\AC\([-+*/()\d]+\)\z}i)
   end
 
   def dice_command   # ダイスコマンドの分岐処理
@@ -71,7 +71,7 @@ class BCDice
   # 用意している。
   def try_calc_command
     stripped_message = @message.strip
-    matches = stripped_message.match(/\AC([-\d]+\z)/i)
+    matches = stripped_message.match(/\AC(-?\d+)\z/i)
 
     if matches.nil?
       return nil, nil

--- a/lib/bcdice_wrap.rb
+++ b/lib/bcdice_wrap.rb
@@ -26,10 +26,7 @@ class BCDice
   # 詳細な構文解析は行わない。
   # 計算コマンドで使われ得る文字のみで構成されているかどうかだけを調べる。
   def self.seem_to_be_calc?(s)
-    # 空白が含まれる場合、最初の部分だけを取り出す
-    target = s.split(/\s/, 2).first
-
-    return target.match?(%r{\AC\([-+*/()\d]+\)\z}i)
+    return s.match?(%r{\AC\([-+*/()\d]+\)}i)
   end
 
   def dice_command   # ダイスコマンドの分岐処理

--- a/lib/bcdice_wrap.rb
+++ b/lib/bcdice_wrap.rb
@@ -61,12 +61,21 @@ class BCDice
   end
 
   # 計算コマンドの実行を試みる
+  # @param [String] command 入力されたコマンド
   # @return [Array<String, false>] 計算コマンドの実行に成功した場合
   # @return [nil, nil] 計算コマンドの実行に失敗した場合
   #
   # 返り値の2つ目の要素は、`result, secret =` と受け取れるようにするために
   # 用意している。
-  def try_calc_command
+  def try_calc_command(command)
+    # "C(1+1)" のような計算コマンドは受け付けるが、"C1" のように "C" の後に数字
+    # のみが書かれているコマンドなどは拒絶するために必要な処理。
+    # BCDice側では、設定されたメッセージが計算コマンドかどうかの判定を行って
+    # いないため、やむを得ずここで判定する。
+    unless self.class.seem_to_be_calc?(command)
+      return nil, nil
+    end
+
     stripped_message = @message.strip
     matches = stripped_message.match(/\AC(-?\d+)\z/i)
 

--- a/server.rb
+++ b/server.rb
@@ -34,15 +34,7 @@ helpers do
     result, secret = bcdice.dice_command
 
     if result.nil?
-      # 計算コマンドの実行を試みる
-
-      # "C(1+1)" のような計算コマンドは受け付けるが、"C1" のように "C" の後に
-      # 数字のみが書かれているコマンドなどは拒絶するために必要な処理。
-      # BCDice側では、設定されたメッセージが計算コマンドかどうかの判定を行って
-      # いないため、やむを得ずここで判定する。
-      if BCDice.seem_to_be_calc?(command)
-        result, secret = bcdice.try_calc_command
-      end
+      result, secret = bcdice.try_calc_command(command)
     end
 
     dices = bcdice.getRandResults.map {|dice| {faces: dice[1], value: dice[0]}}

--- a/server.rb
+++ b/server.rb
@@ -32,6 +32,19 @@ helpers do
     bcdice.setCollectRandResult(true)
 
     result, secret = bcdice.dice_command
+
+    if result.nil?
+      # 計算コマンドの実行を試みる
+
+      # "C(1+1)" のような計算コマンドは受け付けるが、"C1" のように "C" の後に
+      # 数字のみが書かれているコマンドなどは拒絶するために必要な処理。
+      # BCDice側では、設定されたメッセージが計算コマンドかどうかの判定を行って
+      # いないため、やむを得ずここで判定する。
+      if BCDice.seem_to_be_calc?(command)
+        result, secret = bcdice.try_calc_command
+      end
+    end
+
     dices = bcdice.getRandResults.map {|dice| {faces: dice[1], value: dice[0]}}
 
     if result.nil?

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -85,6 +85,7 @@ class API_Test < Test::Unit::TestCase
 
   data("単純な四則演算", "C(1+2-3*4/5)")
   data("括弧を含む四則演算", "C(1+(2-3*4/(5/6))-7)")
+  data("計算コマンドの後に文字列が存在する場合（空白あり）", "C(10+5) mokekeke")
   def test_calc(command)
     get "/v1/diceroll?system=DiceBot&command=#{CGI.escape(command)}"
 
@@ -100,6 +101,7 @@ class API_Test < Test::Unit::TestCase
   data("Cの後に数字のみが続く場合", "C42")
   data("括弧が閉じられていない場合", "C(1+2")
   data("空白で始まる場合", " C(1+2)")
+  data("計算コマンドの後に文字列が存在する場合（空白なし）", "C(10+5)mokekeke")
   def test_pseudo_calc(command)
     get "/v1/diceroll?system=DiceBot&command=#{CGI.escape(command)}"
 

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -92,7 +92,7 @@ class API_Test < Test::Unit::TestCase
 
     assert last_response.ok?
     assert json["ok"]
-    assert json["result"].start_with?("DiceBot : 計算結果 ＞ ")
+    assert json["result"].start_with?(": 計算結果 ＞ ")
     assert_equal json["dices"], []
     assert_false json["secret"]
   end

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -3,6 +3,8 @@ ENV["RACK_ENV"] = "test"
 require "test/unit"
 require "rack/test"
 
+require "cgi"
+
 require File.expand_path "../server.rb", __dir__
 
 class API_Test < Test::Unit::TestCase
@@ -79,6 +81,33 @@ class API_Test < Test::Unit::TestCase
     assert json["result"]
     assert json["dices"]
     assert_false json["secret"]
+  end
+
+  data("単純な四則演算", "C(1+2-3*4/5)")
+  data("括弧を含む四則演算", "C(1+(2-3*4/(5/6))-7)")
+  def test_calc(command)
+    get "/v1/diceroll?system=DiceBot&command=#{CGI.escape(command)}"
+
+    json = JSON.parse(last_response.body)
+
+    assert last_response.ok?
+    assert json["ok"]
+    assert json["result"].start_with?("DiceBot : 計算結果 ＞ ")
+    assert_equal json["dices"], []
+    assert_false json["secret"]
+  end
+
+  data("Cの後に数字のみが続く場合", "C42")
+  data("括弧が閉じられていない場合", "C(1+2")
+  data("空白で始まる場合", " C(1+2)")
+  def test_pseudo_calc(command)
+    get "/v1/diceroll?system=DiceBot&command=#{CGI.escape(command)}"
+
+    json = JSON.parse(last_response.body)
+
+    assert last_response.bad_request?
+    assert_false json["ok"]
+    assert_equal json["reason"], "unsupported command"
   end
 
   def test_unexpected_dicebot

--- a/test/test_bcdice_wrap.rb
+++ b/test/test_bcdice_wrap.rb
@@ -8,7 +8,7 @@ class BCDiceWrapTest < Test::Unit::TestCase
   data("単純な四則演算", ["C(1+2-3*4/5)", true])
   data("括弧を含む四則演算", ["C(1+(2-3*4/(5/6))-7)", true])
   data("計算コマンドの後に文字列が存在する場合（空白あり）", ["C(10+5) mokekeke", true])
-  data("計算コマンドの後に文字列が存在する場合（空白なし）", ["C(10+5)mokekeke", false])
+  data("計算コマンドの後に文字列が存在する場合（空白なし）", ["C(10+5)mokekeke", true])
   data("Cの後に数字のみが続く場合", ["C42", false])
   data("括弧が閉じられていない場合", ["C(1+2", false])
   data("空白で始まる場合", [" C(1+2)", false])

--- a/test/test_bcdice_wrap.rb
+++ b/test/test_bcdice_wrap.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test/unit"
+
+require_relative "../lib/bcdice_wrap.rb"
+
+class BCDiceWrapTest < Test::Unit::TestCase
+  data("単純な四則演算", ["C(1+2-3*4/5)", true])
+  data("括弧を含む四則演算", ["C(1+(2-3*4/(5/6))-7)", true])
+  data("Cの後に数字のみが続く場合", ["C42", false])
+  data("括弧が閉じられていない場合", ["C(1+2", false])
+  data("空白で始まる場合", [" C(1+2)", false])
+  def test_seem_to_be_calc?(data)
+    input, expected = data
+    assert_equal(expected, BCDice.seem_to_be_calc?(input))
+  end
+end

--- a/test/test_bcdice_wrap.rb
+++ b/test/test_bcdice_wrap.rb
@@ -7,6 +7,8 @@ require_relative "../lib/bcdice_wrap.rb"
 class BCDiceWrapTest < Test::Unit::TestCase
   data("単純な四則演算", ["C(1+2-3*4/5)", true])
   data("括弧を含む四則演算", ["C(1+(2-3*4/(5/6))-7)", true])
+  data("計算コマンドの後に文字列が存在する場合（空白あり）", ["C(10+5) mokekeke", true])
+  data("計算コマンドの後に文字列が存在する場合（空白なし）", ["C(10+5)mokekeke", false])
   data("Cの後に数字のみが続く場合", ["C42", false])
   data("括弧が閉じられていない場合", ["C(1+2", false])
   data("空白で始まる場合", [" C(1+2)", false])


### PR DESCRIPTION
これまで実行できなかった計算コマンド `C(...)` を実行できるようにしました。これにより、QuoridornなどのBCDice APIを使用するTRPGツールでも、どどんとふと同様に四則演算の結果を確認することができるようになります。

# 実行例

<img width="805" alt="bcdice-api" src="https://user-images.githubusercontent.com/2551173/61198736-4299b700-a716-11e9-83e4-15d4341efc48.png">
