### PR TITLE
ゲームシステムの読みがなを用いて、ダイスボットをソートする

### DIFF
--- a/lib/bcdice_wrap.rb
+++ b/lib/bcdice_wrap.rb
@@ -4,9 +4,8 @@ require "diceBot/DiceBot"
 require "diceBot/DiceBotLoader"
 
 class BCDice
-  DICEBOTS = (DiceBotLoader.collectDiceBots + [DiceBot.new]).
+  DICEBOTS = ([DiceBot.new] + DiceBotLoader.collectDiceBots).
     map { |diceBot| [diceBot.id, diceBot] }.
-    sort.
     to_h.
     freeze
 


### PR DESCRIPTION
BCDice v2.04.00で導入された、表題の機能を使用します。どどんとふと同様に、最初の項目はゲームシステム未指定（DiceBot）とします。