### PR TITLE
ドキュメントの訂正: faces -> sides

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -197,10 +197,10 @@ WebAPIで利用できるダイスボットのシステムID一覧が返却され
     {"faces" : 10, "value" : 9}
   ],
   "detailed_rands" : [
-    {"kind" : "nomal", "faces" : 10, "value" : 8},
-    {"kind" : "nomal", "faces" : 10, "value" : 2},
-    {"kind" : "nomal", "faces" : 10, "value" : 1},
-    {"kind" : "nomal", "faces" : 10, "value" : 9}
+    {"kind" : "nomal", "sides" : 10, "value" : 8},
+    {"kind" : "nomal", "sides" : 10, "value" : 2},
+    {"kind" : "nomal", "sides" : 10, "value" : 1},
+    {"kind" : "nomal", "sides" : 10, "value" : 9}
   ]
 }
 ```
@@ -216,14 +216,14 @@ WebAPIで利用できるダイスボットのシステムID一覧が返却され
 
 - `nomal`
   - 通常のダイスロール
-  - `{"kind" : "nomal", "faces" : 10, "value" : 8}`
+  - `{"kind" : "nomal", "sides" : 10, "value" : 8}`
 - `tens_d10`
   - 十の位のダイス
-  - `{"kind" : "tens_d10", "faces" : 10, "value" : 80}`
-  - `{"kind" : "tens_d10", "faces" : 10, "value" : 0}`
+  - `{"kind" : "tens_d10", "sides" : 10, "value" : 80}`
+  - `{"kind" : "tens_d10", "sides" : 10, "value" : 0}`
     - `00` は0として扱われます
 - `d9`
   - 十面体を0〜9のダイスとして扱う
-  - `{"kind" : "d9", "faces" : 10, "value" : 0}`
+  - `{"kind" : "d9", "sides" : 10, "value" : 0}`
 
 Since: 0.9.0, BCDice Ver2.04.00

--- a/docs/api_v2.md
+++ b/docs/api_v2.md
@@ -243,15 +243,15 @@ BCDice-APIで利用できるゲームシステムの一覧が返却されます�
 
 - `nomal`
   - 通常のダイスロール
-  - `{"kind" : "nomal", "faces" : 10, "value" : 8}`
+  - `{"kind" : "nomal", "sides" : 10, "value" : 8}`
 - `tens_d10`
   - 十の位のダイス
-  - `{"kind" : "tens_d10", "faces" : 10, "value" : 80}`
-  - `{"kind" : "tens_d10", "faces" : 10, "value" : 0}`
+  - `{"kind" : "tens_d10", "sides" : 10, "value" : 80}`
+  - `{"kind" : "tens_d10", "sides" : 10, "value" : 0}`
     - `00` は0として扱われます
 - `d9`
   - 十面体を0〜9のダイスとして扱う
-  - `{"kind" : "d9", "faces" : 10, "value" : 0}`
+  - `{"kind" : "d9", "sides" : 10, "value" : 0}`
 
 ## Original Table
 


### PR DESCRIPTION
`/v1/diceroll` の `detailed_rands` および `v2/game_system/{id}/roll` の `rands` の説明にて、  
`sides` とあるべき箇所が `faces` と記載されていた


確認時の情報は下記
https://bcdice.herokuapp.com/v2/version
```json
{"api":"2.0.0","bcdice":"3.0.0"}
```

https://bcdice.herokuapp.com/v1/diceroll?command=cc1&system=Cthulhu7th
```json
   "detailed_rands":[
      {
         "kind":"tens_d10",
         "sides":10,
         "value":90
      },
      {
         "kind":"tens_d10",
         "sides":10,
         "value":40
      },
      {
         "kind":"normal",
         "sides":10,
         "value":1
      }
   ]
```

https://bcdice.herokuapp.com/v2/game_system/Cthulhu7th/roll?command=cc1
```json
   "rands":[
      {
         "kind":"tens_d10",
         "sides":10,
         "value":60
      },
      {
         "kind":"tens_d10",
         "sides":10,
         "value":60
      },
      {
         "kind":"normal",
         "sides":10,
         "value":10
      }
   ]
```
