### PR TITLE
bundle updateでBCDiceのメジャーバージョン3に自動的に追従するようにする（依存するBCDiceのアップデート）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'bcdice', '~>3.0.0'
+gem 'bcdice', '~>3.0'
 
 gem 'sinatra', '~>2.0'
 gem 'sinatra-contrib', '~>2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
-    bcdice (3.0.0)
+    ast (2.4.2)
+    bcdice (3.1.1)
       i18n (~> 1.8.5)
     concurrent-ruby (1.1.8)
-    i18n (1.8.7)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.5.4)
+    nio4r (2.5.7)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
-    power_assert (1.2.0)
+    power_assert (2.0.0)
     puma (4.3.7)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -35,7 +35,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
     ruby-progressbar (1.11.0)
-    ruby2_keywords (0.0.2)
+    ruby2_keywords (0.0.4)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -50,7 +50,7 @@ GEM
     sinatra-jsonp (0.5.0)
       multi_json (~> 1.8)
       sinatra (>= 1.0)
-    test-unit (3.3.9)
+    test-unit (3.4.0)
       power_assert
     tilt (2.0.10)
     tomlrb (2.0.1)
@@ -60,7 +60,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bcdice (~> 3.0.0)
+  bcdice (~> 3.0)
   puma (~> 4.3)
   rack-test (~> 1.1)
   rake (~> 13.0)


### PR DESCRIPTION
現在のバージョン指定 `~> 3.0.0` ではBCDice v3.1.1に追従できないため、Gemのバージョン指定を書き換えました。